### PR TITLE
Support all TLDs in proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/ucirello/tcpkeepalive v0.0.0-20180903163222-92daabaeadac
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
+	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9
 	golang.org/x/tools v0.0.0-20201007032633-0806396f153e // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/rpc/proxy.go
+++ b/rpc/proxy.go
@@ -12,14 +12,15 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
-	// "path"
 
 	"github.com/caddyserver/certmagic"
 	"github.com/diodechain/diode_go_client/config"
 	"github.com/diodechain/diode_go_client/util"
 	"github.com/gorilla/websocket"
+	"golang.org/x/net/publicsuffix"
 )
 
 // Config is Proxy Server configuration
@@ -90,22 +91,34 @@ func internalError(w http.ResponseWriter, str string) {
 
 func (proxyServer *ProxyServer) parseHost(host string) (isWS bool, mode string, deviceID string, port int, err error) {
 	mode = defaultMode
-	strPort := ":80"
+	strPort := "80"
+	sh := strings.Split(host, ":")
+	if len(sh) > 1 {
+		host = sh[0]
+		strPort = sh[1]
+	}
 
-	subdomainPort := proxyDomainPattern.FindStringSubmatch(host)
-	var sub, domain string
-	if len(subdomainPort) != 4 {
-		err = fmt.Errorf("domain pattern not supported %v", host)
+	var domain string
+	suffix, icann := publicsuffix.PublicSuffix(host)
+	domain, err = publicsuffix.EffectiveTLDPlusOne(host)
+	// check whether domain is managed by ICANN (usually top level domain)
+	if !icann || err != nil {
+		err = fmt.Errorf("domain is not top level domain %v", host)
 		return
 	}
 
-	sub = subdomainPort[1]
-	domain = subdomainPort[2]
-	if len(subdomainPort[3]) > 0 {
-		strPort = subdomainPort[3]
+	var sub string
+	if len(host) > len(domain) {
+		sub = host[0 : len(host)-len(domain)-1]
+	} else {
+		// apex domain
+		// TODO: support different suffix and subdomain in BNS
+		deviceID = domain[0 : len(domain)-len(suffix)-1]
+		port, err = strconv.Atoi(strPort[:])
+		return
 	}
 
-	isWS = domain == "diode.ws"
+	isWS = (domain == "diode.ws")
 	modeHostPort := subdomainPattern.FindStringSubmatch(sub)
 	if len(modeHostPort) != 4 {
 		err = fmt.Errorf("subdomain pattern not supported %v", sub)
@@ -117,10 +130,10 @@ func (proxyServer *ProxyServer) parseHost(host string) (isWS bool, mode string, 
 	}
 	deviceID = modeHostPort[2]
 	if len(modeHostPort[3]) > 0 {
-		strPort = modeHostPort[3]
+		strPort = modeHostPort[3][1:]
 	}
 
-	port, err = strconv.Atoi(strPort[1:])
+	port, err = strconv.Atoi(strPort[:])
 	return
 }
 

--- a/rpc/socks.go
+++ b/rpc/socks.go
@@ -25,7 +25,7 @@ import (
 var (
 	defaultMode        = "rw"
 	domainPattern      = regexp.MustCompile(`^(.+)\.(diode|diode\.link|diode\.ws)(:[\d]+)?$`)
-	proxyDomainPattern = regexp.MustCompile(`^(.+)\.(diode|diode\.link|diode\.ws|com|io|xyz|live|life|dev|tw)(:[\d]+)?$`)
+	proxyDomainPattern = regexp.MustCompile(`^(.+)\.(diode|diode\.link|diode\.ws)(:[\d]+)?$`)
 	subdomainPattern   = regexp.MustCompile(`^([rws]{1,3}-)?(0x[A-Fa-f0-9]{40}|[A-Za-z0-9][A-Za-z0-9-]{5,30}?)(-[^0][\d]+)?$`)
 
 	errAddrType        = errors.New("socks addr type not supported")


### PR DESCRIPTION
Before we hard code the domain suffix in proxy regex
pattern, now we use golang.org/x/net/publicsuffix to
check the domain list. For more information, please
go to https://publicsuffix.org/.