### PR TITLE
Fix #67

### DIFF
--- a/.diode.yml.example
+++ b/.diode.yml.example
@@ -13,9 +13,7 @@ retrywait: 10s
 # registry:
 # dbpath: ./db
 # keepalive: true
-# keepalivecount: 5
 # keepaliveinterval: 5s
-# keepaliveidle: 30s
 # blocklists:
 #     -
 # allowlists:

--- a/README.MD
+++ b/README.MD
@@ -24,7 +24,7 @@ SYNOPSYS
         [-bind=] [-blocklists=] [-blockprofile=] [-blockprofilerate=1]
         [-configpath=] [-cpuprofile=] [-dbpath=/Users/...] [-debug=false]
         [-diodeaddrs=] [-e2e=true] [-fleet=] [-keepalive=true]
-        [-keepalivecount=4] [-keepaliveidle=30s] [-keepaliveinterval=5s] [-logdatetime=false]
+        [-keepaliveinterval=5s] [-logdatetime=false]
         [-logfilepath=] [-memprofile=] [-metrics=false] [-mutexprofile=]
         [-mutexprofilerate=1] [-retrytimes=3] [-retrywait=1s] [-rlimit_nofile=0]
         [-timeout=5s] [-update=true] COMMAND <args>

--- a/cmd/diode/app.go
+++ b/cmd/diode/app.go
@@ -73,10 +73,8 @@ func init() {
 	diodeCmd.Flag.Var(&cfg.SBlocklists, "blocklists", "addresses are not allowed to connect to published resource (worked when allowlists is empty)")
 	diodeCmd.Flag.Var(&cfg.SAllowlists, "allowlists", "addresses are allowed to connect to published resource (worked when blocklists is empty)")
 	diodeCmd.Flag.Var(&cfg.SBinds, "bind", "bind a remote port to a local port. -bind <local_port>:<to_address>:<to_port>:(udp|tcp)")
-	// tcp keepalive for node connection
+	// tcp keepalive for server connection
 	diodeCmd.Flag.BoolVar(&cfg.EnableKeepAlive, "keepalive", runtime.GOOS != "windows", "enable tcp keepalive (only Linux >= 2.4, DragonFly, FreeBSD, NetBSD and OS X >= 10.8 are supported)")
-	diodeCmd.Flag.IntVar(&cfg.KeepAliveCount, "keepalivecount", 4, "the maximum number of keepalive probes TCP should send before dropping the connection")
-	diodeCmd.Flag.DurationVar(&cfg.KeepAliveIdle, "keepaliveidle", 30*time.Second, "the time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes")
 	diodeCmd.Flag.DurationVar(&cfg.KeepAliveInterval, "keepaliveinterval", 5*time.Second, "the time (in seconds) between individual keepalive probes")
 	config.AppConfig = cfg
 	// Add diode commands

--- a/config/flag.go
+++ b/config/flag.go
@@ -45,8 +45,6 @@ type Config struct {
 	EnableUpdate      bool          `yaml:"update,omitempty" json:"update,omitempty"`
 	EnableMetrics     bool          `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	EnableKeepAlive   bool          `yaml:"keepalive,omitempty" json:"keepalive,omitempty"`
-	KeepAliveCount    int           `yaml:"keepalivecount,omitempty" json:"keepalivecount,omitempty"`
-	KeepAliveIdle     time.Duration `yaml:"keepaliveidle,omitempty" json:"keepaliveidle,omitempty"`
 	KeepAliveInterval time.Duration `yaml:"keepaliveinterval,omitempty" json:"keepaliveinterval,omitempty"`
 	RemoteRPCAddrs    stringValues  `yaml:"diodeaddrs,omitempty" json:"diodeaddrs,omitempty"`
 	RemoteRPCTimeout  time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/ucirello/tcpkeepalive v0.0.0-20180903163222-92daabaeadac
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/net v0.0.0-20200822124328-c89045814202

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,6 @@ github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPf
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
-github.com/ucirello/tcpkeepalive v0.0.0-20180903163222-92daabaeadac h1:LfogUkyZN8fA4VeYWhVTeVGKViZZBzD7HSBoC/E12+0=
-github.com/ucirello/tcpkeepalive v0.0.0-20180903163222-92daabaeadac/go.mod h1:0hzTdinNihT7awDehfnEo7nYlLQwr+j9Qs4ZA9ZTbL0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=

--- a/rpc/bridge.go
+++ b/rpc/bridge.go
@@ -111,6 +111,12 @@ func (rpcClient *RPCClient) handleInboundRequest(inboundRequest interface{}) {
 				rpcClient.Error("Failed to connect local: %v", err)
 				return
 			}
+			if tcpConn, ok := remoteConn.(*net.TCPConn); ok {
+				err := tcpConn.SetKeepAlive(true)
+				if err == nil {
+					tcpConn.SetKeepAlivePeriod(10 * time.Second)
+				}
+			}
 
 			deviceKey := rpcClient.GetDeviceKey(portOpen.Ref)
 			connDevice.Ref = portOpen.Ref

--- a/rpc/e2e_test.go
+++ b/rpc/e2e_test.go
@@ -49,10 +49,7 @@ func testConfig() (cfg *config.Config) {
 		LogDateTime:     false,
 		LogMode:         config.LogToConsole,
 		EnableKeepAlive: runtime.GOOS != "windows",
-		KeepAliveCount:  4,
 	}
-	keepaliveIdleTime, _ := time.ParseDuration("30s")
-	cfg.KeepAliveIdle = keepaliveIdleTime
 	keepaliveIntervalTime, _ := time.ParseDuration("5s")
 	cfg.KeepAliveInterval = keepaliveIntervalTime
 	remoteRPCTimeoutTime, _ := time.ParseDuration("5s")


### PR DESCRIPTION
Fix #67

TODO:
~- [ ] SetKeepAliveCount/SetKeepAliveIdle
https://github.com/ucirello/tcpkeepalive/blob/master/keepalive_darwin.go~

~- [ ] Check whether there is Keep-Alive inhttp header
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive~

~- [ ] Keep Alive for other protocols?~

After trace ghost backend (nodejs/express) and proxy connection, it turns out 
the first byte was missing in next request, eg: `ET /api/v3/admin/config`, it should
be `GET /api/v3/admin/config`. So the nodejs socket rejected request with:

`HPE_INVALID_METHOD`

```JS
[Error: Parse Error]
  bytesParsed: 0,
  code: 'HPE_INVALID_METHOD',
  rawPacket:
```